### PR TITLE
Remove missed feature import

### DIFF
--- a/egs/iemocap/emo/v1/local/python/dump_data_from_pickle.py
+++ b/egs/iemocap/emo/v1/local/python/dump_data_from_pickle.py
@@ -11,7 +11,6 @@ import wave
 from scipy.io import wavfile
 
 from dump_all_data import gen_all_data
-from features import *
 from helper import *
 import kaldiio
 


### PR DESCRIPTION
Running the IEMOCAP example throws an error when trying to import module `features` in `egs/iemocap/emo/v1/local/python/dump_data_from_pickle.py `. This module is not needed and was removed recently. This change fixes the error.

**How to test**: run `egs/iemocap/emo/v1/run.sh`
After this change, the run will run without errors (given the dataset is available).
