### PR TITLE
add unittest for CE loss on misclassified examples

### DIFF
--- a/delta/utils/loss/loss_utils_test.py
+++ b/delta/utils/loss/loss_utils_test.py
@@ -38,11 +38,15 @@ class LossUtilTest(tf.test.TestCase):
     self.seq_labels = np.array([[5, 1, 1], [3, 2, 0]], dtype=np.int32)
     self.input_length = np.array([[3, 2]], dtype=np.int32)
     self.label_length = np.array([3, 2], dtype=np.int32)
+    # test misclassified examples
+    self.logits_2 = np.array([[10, 2, 3, 4, 5, 6], [2, 3, 10, 4, 5, 1]],
+                           dtype=np.float32)
 
   def tearDown(self):
     ''' tear down '''
 
   def test_cross_entropy(self):
+
     ''' test cross entropy'''
     with self.cached_session():
       loss = loss_utils.cross_entropy(
@@ -51,6 +55,11 @@ class LossUtilTest(tf.test.TestCase):
           labels=tf.constant(self.labels),
           label_length=None)
       self.assertAllClose(loss.eval(), 0.0, rtol=1e-06, atol=1.5e-6)
+
+      loss_2 = loss_utils.cross_entropy(
+          logits=tf.constant(self.logits_2),
+          labels=tf.constant(self.labels))
+      self.assertAllClose(loss_2.eval(), 6.5194526, rtol=1e-06, atol=1.5e-6)
 
       loss = loss_utils.cross_entropy(
           logits=tf.constant(self.seq_logits),


### PR DESCRIPTION
**Thank you for submitting a pull request! Please provide the following information for code review:**

# Pull Request Summary
Current loss unittests only test on correct examples. It is necessary to add test for wrong examples. I only implement this for cross entropy in this PR, but ideally, this should apply to all loss unittests. 

# Test Plan
`python delta/utils/loss/loss_utils_test.py`
Test pass

# Reviewers
@applenob @zh794390558 
