### PR TITLE
fix for abseil not support avx compile

### DIFF
--- a/deltann/targets/linux_makefile.inc
+++ b/deltann/targets/linux_makefile.inc
@@ -3,8 +3,8 @@ ifeq ($(TARGET), linux)
     CXX := g++
     CC := gcc
     AR := ar
-    CXXFLAGS += -std=c++11 -fPIC -mavx -O3
-    CCFLAGS += -fPIC -mavx -O3
+    CXXFLAGS += -std=c++11 -fPIC -O3
+    CCFLAGS += -fPIC -O3
 
     ifeq ($(ENGINE),TF)
         $(info this will compile with $(ENGINE))

--- a/dpl/run.sh
+++ b/dpl/run.sh
@@ -178,7 +178,7 @@ function compile_deltann(){
 function compile_deltann_egs(){
   echo "Compile deltann examples..."
   pushd ${MAIN_ROOT}/deltann
-  make example || { echo "Compile deltann examples error"; exit 1; }
+  make examples || { echo "Compile deltann examples error"; exit 1; }
   popd
   echo "Compile deltann examples done."
   echo


### PR DESCRIPTION
**Thank you for submitting a pull request! Please provide the following information for code review:**

# Pull Request Summary
fix this error for deltann-cpu-py3 image.
```
In file included from /delta/deltann//../tools/abseil-cpp/absl/strings/str_cat.h:63:0,
                 from /delta/deltann//../tools/abseil-cpp/absl/strings/internal/str_join_internal.h:43,
                 from /delta/deltann//../tools/abseil-cpp/absl/strings/str_join.h:59,
                 from /delta/deltann//../tools/tensorflow/tensorflow/core/lib/core/errors.h:21,
                 from /delta/deltann//../tools/tensorflow/tensorflow/core/framework/tensor_shape.h:23,
                 from /delta/deltann/core/shape.h:25,
                 from /delta/deltann/core/io.h:22,
                 from /delta/deltann/core/data.h:25,
                 from /delta/deltann/core/base_model.h:24,
                 from /delta/deltann/core/tfmodel.h:25,
                 from core/tfmodel.cc:23:
/delta/deltann//../tools/abseil-cpp/absl/strings/numbers.h: In function ‘size_t absl::numbers_internal::FastHexToBufferZeroPad16(uint64_t, char*)’:
/delta/deltann//../tools/abseil-cpp/absl/strings/numbers.h:197:12: error: ‘_mm_loadu_si64’ was not declared in this scope
   auto v = _mm_loadu_si64(reinterpret_cast<__m128i*>(&be));  // load lo dword
            ^~~~~~~~~~~~~~
/delta/deltann//../tools/abseil-cpp/absl/strings/numbers.h:197:12: note: suggested alternative: ‘_mm_loadl_epi64’
   auto v = _mm_loadu_si64(reinterpret_cast<__m128i*>(&be));  // load lo dword
            ^~~~~~~~~~~~~~
            _mm_loadl_epi64
Makefile:125: recipe for target '/delta/deltann/.gen/obj/core/tfmodel.o' failed
make: *** [/delta/deltann/.gen/obj/core/tfmodel.o] Error 1
build deltann error
```

# Test Plan
dpl compile deltann pass.
