### PR TITLE
Updated README to add where kaldi folder should be placed, udpated co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ cd tools
 
 **Note**: Users from mainland China may need to set up conda mirror sources, see [./tools/install/install-delta.sh](tools/install/install-delta.sh) for details.
 
-If you want to use both NLP and speech packages, you can install the `full` version. The full version needs [Kaldi](https://github.com/kaldi-asr/kaldi) library, which can be pre-installed or installed using our installation script.
+If you want to use both NLP and speech packages, you can install the `full` version. The full version needs [Kaldi](https://github.com/kaldi-asr/kaldi) library, which can be pre-installed or installed using our installation script. You can also copy the kaldi root folder directly to tools/
 
 ```shell
 cd tools

--- a/core/ops/build.sh
+++ b/core/ops/build.sh
@@ -25,8 +25,8 @@ if [ $target == 'delta' ];then
     local_ver=`gcc --version | grep ^gcc | sed 's/^.* //g'`
     tf_ver=`python -c "import tensorflow as tf; print(tf.version.COMPILER_VERSION.split()[0]);"`
     if [  ${local_ver:0:1} -ne ${tf_ver:0:1} ];then
-      echo "gcc version($local_ver) not compatiable with tf compile version($tf_ver)"
-      exit -1
+      echo "Warning: gcc version($local_ver) not recommended for tf compile version($tf_ver), please use gcc 7.3 toolchain"
+      #exit -1; commenting out, since the library will build with gcc 7.5 and others, allow users to try.
     fi
 fi
 

--- a/tools/install/install-delta.sh
+++ b/tools/install/install-delta.sh
@@ -49,7 +49,7 @@ fi
 CONDA_ENV=delta-py${PY_VER}-tf${TF_VER}
 
 conda create -n ${CONDA_ENV} python=${PY_VER}
-source activate ${CONDA_ENV}
+conda activate ${CONDA_ENV} # updated for conda versions 4.6+
 echo "Conda: ${CONDA_ENV} activated!"
 
 


### PR DESCRIPTION
**Thank you for submitting a pull request! Please provide the following information for code review:**

# Pull Request Summary
Updated README to add where kaldi folder should be placed, udpated conda activate in the install script for versions after 4.6, changed defult behavior of the gcc check to WARN instead of ERROR, so users can try to install with the 7.X toolchain instead of just 7.3.1

# Test Plan
```./install/install-delta.sh full cpu``` should now work on newer OS & with newer anaconda versions, also you may try to run it after kaldi has been cloned and build inside ```tools/``` as in the updated README.
