### PR TITLE
Fix gdrive CNN dataset download and processing

### DIFF
--- a/egs/cnn_dailymail/seq2seq/v1/local/make_datafiles.py
+++ b/egs/cnn_dailymail/seq2seq/v1/local/make_datafiles.py
@@ -20,7 +20,7 @@ all_test_urls = "cnn-dailymail/url_lists/all_test.txt"
 
 cnn_tokenized_stories_dir = "cnn_stories_tokenized"
 
-num_expected_cnn_stories = 92578
+num_expected_cnn_stories = 925789
 
 VOCAB_SIZE = 200000
 

--- a/egs/cnn_dailymail/seq2seq/v1/run.sh
+++ b/egs/cnn_dailymail/seq2seq/v1/run.sh
@@ -7,7 +7,7 @@ data=./data
 if [ ${start_stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     # download data
     [ -d $data ] || mkdir -p $data || exit 1;
-    wget -P $data https://drive.google.com/uc?export=download&id=0BwmD_VLjROrfTHk4NFg2SndKcjQ || exit 1
+    wget --no-check-certificate --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=0BwmD_VLjROrfTHk4NFg2SndKcjQ' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=0BwmD_VLjROrfTHk4NFg2SndKcjQ" -O $data/cnn_stories.tgz && rm -rf /tmp/cookies.txt || exit 1    
     tar zxvf $data/cnn_stories.tgz  -C $data || exit 1
 fi
 


### PR DESCRIPTION
# Pull Request Summary
- Fixed bug when downloading the CNN dataset from gdrive. Previous bug because of the new requirement regarding cookies
- Fixed variable in the processing of the file. The number of expected stories was incorrect.